### PR TITLE
fix: queue timeout for NovelAI

### DIFF
--- a/discord_bot/discord_bot.go
+++ b/discord_bot/discord_bot.go
@@ -196,10 +196,10 @@ func (b *botImpl) Start() error {
 		return fmt.Errorf("error opening connection to Discord: %w", err)
 	}
 
-	//err = b.registerCommands()
-	//if err != nil {
-	//	return fmt.Errorf("error registering commands: %w", err)
-	//}
+	err = b.registerCommands()
+	if err != nil {
+		return fmt.Errorf("error registering commands: %w", err)
+	}
 
 	b.registerHandlers()
 

--- a/main.go
+++ b/main.go
@@ -18,8 +18,6 @@ import (
 	"stable_diffusion_bot/repositories/image_generations"
 	"strings"
 
-	_ "stable_diffusion_bot/pprof"
-
 	openai "github.com/ellypaws/inkbunny-sd/llm"
 	"github.com/joho/godotenv"
 )

--- a/queue/novelai/process.go
+++ b/queue/novelai/process.go
@@ -64,6 +64,11 @@ func (q *NAIQueue) done() {
 // updateWaiting updates all queued items with their new position
 func (q *NAIQueue) updateWaiting() {
 	items := len(q.queue)
+
+	if items == 0 {
+		return
+	}
+
 	finished := make(chan *NAIQueueItem, items)
 
 	var position int

--- a/queue/novelai/process.go
+++ b/queue/novelai/process.go
@@ -90,10 +90,10 @@ func (q *NAIQueue) updateWaiting() {
 	updated.Wait()
 
 	timeout := time.NewTimer(30 * time.Second)
-	defer drain(timeout)
 	for range items {
 		select {
 		case q.queue <- <-finished:
+			drain(timeout)
 		case <-timeout.C:
 			log.Printf("Error updating queue position: timeout")
 			return

--- a/queue/novelai/process.go
+++ b/queue/novelai/process.go
@@ -93,12 +93,13 @@ func (q *NAIQueue) updateWaiting() {
 	for range items {
 		select {
 		case q.queue <- <-finished:
-			drain(timeout)
 		case <-timeout.C:
 			log.Printf("Error updating queue position: timeout")
 			return
 		}
 	}
+
+	drain(timeout)
 }
 
 func drain(t *time.Timer) {

--- a/queue/novelai/text_to_image.go
+++ b/queue/novelai/text_to_image.go
@@ -61,6 +61,7 @@ func (q *NAIQueue) processImagineGrid(item *NAIQueueItem, promise chan<- error) 
 	embed, err := q.showInitialMessage(item)
 	if err != nil {
 		promise <- err
+		return
 	}
 
 	generationDone := make(chan bool)
@@ -74,6 +75,7 @@ func (q *NAIQueue) processImagineGrid(item *NAIQueueItem, promise chan<- error) 
 		generationDone <- true
 		if err != nil {
 			promise <- fmt.Errorf("error generating image: %w", err)
+			return
 		}
 
 		message := fmt.Sprintf("%s\n\nUploading image...", imagineMessageSimple(item.Request, item.user))
@@ -82,6 +84,7 @@ func (q *NAIQueue) processImagineGrid(item *NAIQueueItem, promise chan<- error) 
 		})
 		if err != nil {
 			promise <- err
+			return
 		}
 
 		promise <- q.showFinalMessage(item, images, embed)

--- a/queue/novelai/text_to_image.go
+++ b/queue/novelai/text_to_image.go
@@ -57,7 +57,6 @@ func (q *NAIQueue) processCurrentItem() (*discordgo.Interaction, error) {
 
 func (q *NAIQueue) processImagineGrid(item *NAIQueueItem, promise chan<- error) {
 	defer close(promise)
-	request := item.Request
 
 	embed, webhook, err := q.showInitialMessage(item)
 	if err != nil {
@@ -71,7 +70,7 @@ func (q *NAIQueue) processImagineGrid(item *NAIQueueItem, promise chan<- error) 
 	switch item.Type {
 	case ItemTypeImage, ItemTypeVibeTransfer, ItemTypeImg2Img:
 		item.Created = time.Now()
-		images, err := q.client.Inference(request)
+		images, err := q.client.Inference(item.Request)
 		generationDone <- true
 		if err != nil {
 			promise <- fmt.Errorf("error generating image: %w", err)

--- a/queue/novelai/text_to_image.go
+++ b/queue/novelai/text_to_image.go
@@ -119,6 +119,8 @@ func (q *NAIQueue) updateProgressBar(item *NAIQueueItem, generationDone <-chan b
 	start := time.Now()
 	visual := spinner.Moon.Frames
 	message := imagineMessageSimple(item.Request, item.user)
+	timeout := time.NewTimer(5 * time.Minute)
+	defer drain(timeout)
 
 	var frame int
 	for {
@@ -144,7 +146,7 @@ func (q *NAIQueue) updateProgressBar(item *NAIQueueItem, generationDone <-chan b
 				return
 			}
 			fmt.Printf("\r%s Time elapsed: %s (%s)", visual[frame], elapsed, item.user.Username)
-		case <-time.After(5 * time.Minute):
+		case <-timeout.C:
 			log.Printf("Generation #%s has been running for 5 minutes, interrupting", item.DiscordInteraction.ID)
 			break
 		}

--- a/queue/novelai/text_to_image.go
+++ b/queue/novelai/text_to_image.go
@@ -40,7 +40,6 @@ func (q *NAIQueue) processCurrentItem() (*discordgo.Interaction, error) {
 	defer drain(timeout)
 
 	promise := make(chan error)
-	defer close(promise)
 	go q.processImagineGrid(item, promise)
 
 	select {
@@ -57,6 +56,7 @@ func (q *NAIQueue) processCurrentItem() (*discordgo.Interaction, error) {
 }
 
 func (q *NAIQueue) processImagineGrid(item *NAIQueueItem, promise chan<- error) {
+	defer close(promise)
 	request := item.Request
 
 	embed, webhook, err := q.showInitialMessage(item)


### PR DESCRIPTION
Fixes queue grinding to a halt when a timeout fires as previously calling the drain method would block. this has been resolved in 6fd23e273ef4723c1ed11e742b8f9f0364ffd8c6, but also notably an upgrade to 1.23.0 proposes unbuffered channel and garbage collected immediately

fix: be more explicit when calling drain as it might block
calling drain when we already have received from the channel will block. this caused the queue to halt when a timeout has occurred, as the timeout select will have drained the channel, but the drain method is trying to receive from the channel again.

refs: 6fd23e273ef4723c1ed11e742b8f9f0364ffd8c6